### PR TITLE
[QMenu] Remove whitespace and add "checked" icon style

### DIFF
--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -153,12 +153,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #bd93f9;
+    border: 2px #bd93f9;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>Dracula</name>
   <description>Dracula dark theme for FreeCAD</description>
-  <version>0.0.1</version>
+  <version>0.0.2</version>
   <maintainer email="tim@clifford.lol">Tim Clifford</maintainer>
   <license file="LICENSE">MIT</license>
   <url type="repository" branch="master">https://github.com/dracula/freecad</url>


### PR DESCRIPTION
Please see related issue https://github.com/dracula/freecad/issues/4

All stylesheets other than ExtremeProDark have superfluous whitespace in dropdowns, but lack any highlighting for "checked" icons such as Orthographic vs Perspective view.
This PR adds solution proposed by [MisterMakerNL](https://github.com/MisterMakerNL) in said issue.

I have chosen "Purple - #bd93f9" from the Dracula palette as the "checked" color here to fit the theme.

Before:
![image](https://user-images.githubusercontent.com/39636046/179039101-f8936d26-6d2b-4222-a3e8-42d80454df75.png)

After:
![image](https://user-images.githubusercontent.com/39636046/179039143-bae79cad-d63a-4816-8764-0c589db3424e.png)