### PR TITLE
Use Dracula purple for "..." table fields

### DIFF
--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -806,7 +806,7 @@ Gui--PropertyEditor--PropertyEditor QAbstractSpinBox:disabled {
 
 /* hack to hide weird redundant information inside cells with links and no editable data (but editable via "..." button) */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
-	color: #535d7f;
+	color: #bd93f9;
 	background-color: #6272a4; /* same as focused background color */
 }
 


### PR DESCRIPTION
Fixes #12 while maintaining visual difference to indicate uneditable field and without deviating from theme.

> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.
Before:
![image](https://user-images.githubusercontent.com/650565/218212466-4f7ea5a9-7fd2-4f9c-85fa-add779951f95.png)

After:
![image](https://user-images.githubusercontent.com/650565/218211808-551736e2-5b7d-45e0-a243-2a42b767f624.png)
