### PR TITLE
Rework Spreadsheet colors

### DIFF
--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -71,6 +71,7 @@
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeEditColor" Value="3180591615"/>
+          <FCUInt Name="TreeActiveColor" Value="2541078527"/>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">
           <FCText Name="StyleSheet">Dracula.qss</FCText>

--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -71,7 +71,6 @@
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeEditColor" Value="3180591615"/>
-          <FCUInt Name="TreeActiveColor" Value="2541078527"/>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">
           <FCText Name="StyleSheet">Dracula.qss</FCText>

--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -85,6 +85,12 @@
             <FCUInt Name="LinkColor" Value="1358593023"/>
             <FCUInt Name="BackgroundColor2" Value="2141107711"/>
           </FCParamGroup>
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#9775C7</FCText>
+            <FCText Name="TextColor">#f8f8f2</FCText>
+            <FCText Name="PositiveNumberColor">#f8f8f2</FCText>
+            <FCText Name="NegativeNumberColor">#f8f8f2</FCText>
+          </FCParamGroup>
         </FCParamGroup>
       </FCParamGroup>
     </FCParamGroup>

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -2033,13 +2033,9 @@ QToolBar QToolButton#qt_toolbar_ext_button:on {
 Tables (spreadsheets)
 ==================================================================================================*/
 QTableView {
-    gridline-color: #6e707f;
+    gridline-color: #44475a;
     selection-color: #535d7f;
     selection-background-color: #8be9fd;
-}
-
-QTableView::item:hover  {
-    background-color: rgba(0,0,0,10);  /* temporal: is it displayed in Linux or Windows? on OSX it isn't */
 }
 
 QTableView::item:disabled  {
@@ -2047,9 +2043,10 @@ QTableView::item:disabled  {
 }
 
 QTableView::item:selected  {
-    color: #535d7f;
-    border-color: #f8f8f2; /* same as focused background color */
+    color: #f8f8f2;
+    border-color: #f8f8f2; /* same as focused background color*/
     border-bottom-color: #ffb86c; /* same as focused border color */
+    background-color: #6272a4; /* must be defined?: aliased cells default to "regular" color when selected if this style is not explicitly set*/
 }
 
 /* fix for elements inside the cells */


### PR DESCRIPTION
After figuring out how to set the background color for aliased cells I got to work configuring the rest of the spreadsheet colors. These settings only affect cells that do not have user-set colors.

Before (3 rows highlighted):
![Dracula theme before Spreadsheet fixes](https://user-images.githubusercontent.com/650565/218288243-027e4e8f-34c4-42e5-9892-e69d930146a7.png)

After (same 3 rows highlighted):
![Dracula theme Spreadsheet Fixes](https://user-images.githubusercontent.com/650565/218288247-92f67b9d-0c25-46a4-b418-6db483bf8269.png)

The alias cell color is Dracula purple but  I had to go 2 shades darker as it was quite a lot of color and not as easy to read white text on.

Fixes #9 and fixes #11.