### PR TITLE
Treeviewfixes

### DIFF
--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -71,6 +71,7 @@
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeEditColor" Value="3180591615"/>
+          <FCUInt Name="TreeActiveColor" Value="2541078527"/>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">
           <FCText Name="StyleSheet">Dracula.qss</FCText>

--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -70,7 +70,7 @@
           <FCUInt Name="HiddenLineBackground" Value="4294967040"/>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
-          <FCUInt Name="TreeEditColor" Value="3180591615"/>
+          <FCUInt Name="TreeEditColor" Value="4286170879"/>
           <FCUInt Name="TreeActiveColor" Value="2541078527"/>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">

--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -85,6 +85,12 @@
             <FCUInt Name="LinkColor" Value="1358593023"/>
             <FCUInt Name="BackgroundColor2" Value="2141107711"/>
           </FCParamGroup>
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#9775C7</FCText>
+            <FCText Name="TextColor">#f8f8f2</FCText>
+            <FCText Name="PositiveNumberColor">#f8f8f2</FCText>
+            <FCText Name="NegativeNumberColor">#f8f8f2</FCText>
+          </FCParamGroup>
         </FCParamGroup>
       </FCParamGroup>
     </FCParamGroup>

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -749,26 +749,24 @@ Tree and list views
 QTreeView,
 QListView,
 QTableView {
-    color: #d5d6da;
+    color: #f8f8f2;
     background-color: #282a36;
     alternate-background-color: #1b1c24; /* related with QListView background  */
     border: 1px solid #1b1c24;
     selection-color: #ffffff;
     selection-background-color: #6272a4; /* should be similar to QListView::item selected background-color */
-    show-decoration-selected: 1; /* make the selection span the entire width of the view */
     border-radius: 3px;
-}
-
-QListView::item:hover,
-QTreeView::item:hover  {
-    background-color: transparent; /* fix to homogenize it on all OSs */
 }
 
 QListView::item:selected,
 QTreeView::item:selected  {
     color: #ffffff; /* should be similar to QListView selection-color */
     background-color: #6272a4; /* should be similar to QListView selection-background-color */
-    show-decoration-selected: 1; /* make the selection span the entire width of the view */
+}
+
+QListView,
+QTableView {
+    show-decoration-selected: 1;
 }
 
 /* Property Editor QTreeView (FreeCAD custom widget) */

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -2033,13 +2033,9 @@ QToolBar QToolButton#qt_toolbar_ext_button:on {
 Tables (spreadsheets)
 ==================================================================================================*/
 QTableView {
-    gridline-color: #6e707f;
+    gridline-color: #44475a;
     selection-color: #535d7f;
     selection-background-color: #8be9fd;
-}
-
-QTableView::item:hover  {
-    background-color: rgba(0,0,0,10);  /* temporal: is it displayed in Linux or Windows? on OSX it isn't */
 }
 
 QTableView::item:disabled  {
@@ -2047,9 +2043,10 @@ QTableView::item:disabled  {
 }
 
 QTableView::item:selected  {
-    color: #535d7f;
-    border-color: #f8f8f2; /* same as focused background color */
+    color: #f8f8f2;
+    border-color: #f8f8f2; /* same as focused background color*/
     border-bottom-color: #ffb86c; /* same as focused border color */
+    background-color: #6272a4; /* must be defined?: aliased cells default to "regular" color when selected if this style is not explicitly set*/
 }
 
 /* fix for elements inside the cells */

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -764,6 +764,10 @@ QTreeView::item:selected  {
     background-color: #6272a4; /* should be similar to QListView selection-background-color */
 }
 
+QTreeView {
+    show-decoration-selected: 0;
+}
+
 QListView,
 QTableView {
     show-decoration-selected: 1;


### PR DESCRIPTION
> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

Before: hard to read active body names due to bright highlight. Full-width selection inconsistent with active/editing part. Hovering over items causes distracting flashing.
[Treeview Fixes before.webm](https://user-images.githubusercontent.com/650565/221385708-67870830-c446-441a-838f-fed829e8050c.webm)


After: legible active body names, dracula pink highlights for item being edited. The pink edit color really stands out, which lets you know "hey, something is in progress in the Tasks tab." You really shouldn't see the pink edit color very often as you'll be in the Tasks tab.
![Treeview Fixes after](https://user-images.githubusercontent.com/650565/221385721-915bf505-fc90-4613-bb00-39055a802cce.png)

Partially fixes #25, fixes #10

Unfortunately, #25 can't be completely fixed through theming as selections include the Description column of the TreeView and Active/Edit highlights do not.