### PR TITLE
Darken colors in view

### DIFF
--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -71,6 +71,7 @@
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeEditColor" Value="3180591615"/>
+          <FCUInt Name="TreeActiveColor" Value="2541078527"/>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">
           <FCText Name="StyleSheet">Dracula.qss</FCText>

--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -35,8 +35,8 @@
           <FCBool Name="Simple" Value="0"/>
           <FCBool Name="Gradient" Value="1"/>
           <FCBool Name="UseBackgroundColorMid" Value="0"/>
-          <FCUInt Name="HighlightColor" Value="3180591615"/>
-          <FCUInt Name="SelectionColor" Value="2347367935"/>
+          <FCUInt Name="HighlightColor" Value="1145527039"/>
+          <FCUInt Name="SelectionColor" Value="1651680511"/>
           <FCUInt Name="DefaultShapeColor" Value="3435973887"/>
           <FCBool Name="RandomColor" Value="0"/>
           <FCUInt Name="DefaultShapeLineColor" Value="421075455"/>

--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -85,6 +85,12 @@
             <FCUInt Name="LinkColor" Value="1358593023"/>
             <FCUInt Name="BackgroundColor2" Value="2141107711"/>
           </FCParamGroup>
+          <FCParamGroup Name="Spreadsheet">
+            <FCText Name="AliasedCellBackgroundColor">#9775C7</FCText>
+            <FCText Name="TextColor">#f8f8f2</FCText>
+            <FCText Name="PositiveNumberColor">#f8f8f2</FCText>
+            <FCText Name="NegativeNumberColor">#f8f8f2</FCText>
+          </FCParamGroup>
         </FCParamGroup>
       </FCParamGroup>
     </FCParamGroup>

--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -35,7 +35,7 @@
           <FCBool Name="Simple" Value="0"/>
           <FCBool Name="Gradient" Value="1"/>
           <FCBool Name="UseBackgroundColorMid" Value="0"/>
-          <FCUInt Name="HighlightColor" Value="1145527039"/>
+          <FCUInt Name="HighlightColor" Value="4286170879"/>
           <FCUInt Name="SelectionColor" Value="1651680511"/>
           <FCUInt Name="DefaultShapeColor" Value="3435973887"/>
           <FCBool Name="RandomColor" Value="0"/>

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -2033,13 +2033,9 @@ QToolBar QToolButton#qt_toolbar_ext_button:on {
 Tables (spreadsheets)
 ==================================================================================================*/
 QTableView {
-    gridline-color: #6e707f;
+    gridline-color: #44475a;
     selection-color: #535d7f;
     selection-background-color: #8be9fd;
-}
-
-QTableView::item:hover  {
-    background-color: rgba(0,0,0,10);  /* temporal: is it displayed in Linux or Windows? on OSX it isn't */
 }
 
 QTableView::item:disabled  {
@@ -2047,9 +2043,10 @@ QTableView::item:disabled  {
 }
 
 QTableView::item:selected  {
-    color: #535d7f;
-    border-color: #f8f8f2; /* same as focused background color */
+    color: #f8f8f2;
+    border-color: #f8f8f2; /* same as focused background color*/
     border-bottom-color: #ffb86c; /* same as focused border color */
+    background-color: #6272a4; /* must be defined?: aliased cells default to "regular" color when selected if this style is not explicitly set*/
 }
 
 /* fix for elements inside the cells */


### PR DESCRIPTION
> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

Before:
![Viewcolor Before](https://user-images.githubusercontent.com/650565/221386437-48a0a25b-f863-4143-a390-5c353690f226.png)

After:
![Viewcolor After](https://user-images.githubusercontent.com/650565/221386445-670fd137-2832-4a55-9458-b88f9104479b.png)

FC selection highlight colors are automatically pumped up brighter when a body is selected in the tree (re #20) so I tried to find something that stuck with the theme, looked okay on the dark background during selection, and wasn't as bright. Also makes it easier to see the shape during highlights.

Fixes #20.