### PR TITLE
Rework sketcher colors to be more in line with default theme

### DIFF
--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -47,19 +47,16 @@
           <FCUInt Name="SketchVertexColor" Value="4177064703"/> <!-- F8F8F2; Colors outside Sketcher: Vertex -->
           <FCUInt Name="EditedEdgeColor" Value="4177064703"/> <!-- F8F8F2; Edge: Unconstrained -->
           <FCUInt Name="EditedVertexColor" Value="4283782655"/> <!-- FF5555; Vertex: Unconstrained -->
-          <FCUInt Name="ConstructionColor" Value="1465384959"/> <!-- 5757FF; Construction Geometry: Unconstrained -->
-          <!-- 5757FF: This blue is the Triadic complement to Dracula Red -->
-          <FCUInt Name="ExternalColor" Value="4286170879"/> <!-- #ff79c6 (default is cc3373); Extermal geometry -->
+          <FCUInt Name="ConstructionColor" Value="1803681791"/> <!-- 6B81FF; Construction Geometry: Unconstrained -->
+          <FCUInt Name="ExternalColor" Value="4286170879"/> <!-- #ff79c6 (default is cc3373); External geometry -->
           <FCUInt Name="FullyConstrainedColor" Value="1358593023"/> <!-- 50FA7B; Fully constrained Sketch -->
           <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/> <!-- B2B27F; Internal alignment edge: Unconstrained -->
           <FCUInt Name="FullyConstraintElementColor" Value="2161156351"/> <!-- 80d0a0; Edge: Constrained -->
-          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2678063103"/> <!-- 9F9FFF; Construction geometry: Constrained -->
-          <!-- Lighter tint of 5757FF from above. -->
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2695823359"/> <!-- A0AEFF; Construction geometry: Constrained -->
           <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/> <!-- DEDEC8; Internal alignment edge: Constrained -->
           <FCUInt Name="FullyConstraintConstructionPointColor" Value="4288651263"/> <!-- FF9F9F; Vertex: Constrained -->
-          <!-- Lighter tint of Dracula Red -->
           <FCUInt Name="ConstrainedIcoColor" Value="4283782655"/> <!-- FF5555; Constraint symbols -->
-          <FCUInt Name="NonDrivingConstrDimColor" Value="1465384959"/> <!-- 5757FF; Reference constraint -->
+          <FCUInt Name="NonDrivingConstrDimColor" Value="1803681791"/> <!-- 6B81FF; Reference constraint -->
           <FCUInt Name="ConstrainedDimColor" Value="4283782655"/> <!-- FF5555; Dimensional constraint -->
           <FCUInt Name="ExprBasedConstrDimColor" Value="4290276607"/> <!-- #FFB86C; Expression dependent constraint -->
           <FCUInt Name="DeactivatedConstrDimColor" Value="2139062271"/> <!-- 7f7f7f; Deactivated constraint -->

--- a/Dracula/Dracula.cfg
+++ b/Dracula/Dracula.cfg
@@ -35,34 +35,38 @@
           <FCBool Name="Simple" Value="0"/>
           <FCBool Name="Gradient" Value="1"/>
           <FCBool Name="UseBackgroundColorMid" Value="0"/>
-          <FCUInt Name="HighlightColor" Value="4286170879"/>
-          <FCUInt Name="SelectionColor" Value="1651680511"/>
+          <FCUInt Name="HighlightColor" Value="3302296063"/> <!-- C4D509; Dracula yellow darkened 50%, similar to default -->
+          <FCUInt Name="SelectionColor" Value="1651680511"/> <!-- #6272A4; Dracula comment, the only color dark enough for selection. -->
           <FCUInt Name="DefaultShapeColor" Value="3435973887"/>
           <FCBool Name="RandomColor" Value="0"/>
           <FCUInt Name="DefaultShapeLineColor" Value="421075455"/>
           <FCUInt Name="DefaultShapeVertexColor" Value="421075455"/>
           <FCUInt Name="BoundingBoxColor" Value="4294967295"/>
-          <FCUInt Name="AnnotationTextColor" Value="3402287871"/>
-          <FCUInt Name="SketchEdgeColor" Value="4177064703"/>
-          <FCUInt Name="SketchVertexColor" Value="4177064703"/>
-          <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
-          <FCUInt Name="EditedVertexColor" Value="4286170879"/>
-          <FCUInt Name="ConstructionColor" Value="2147483647"/>
-          <FCUInt Name="ExternalColor" Value="4290276607"/>
-          <FCUInt Name="FullyConstrainedColor" Value="1358593023"/>
-          <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/>
-          <FCUInt Name="FullyConstraintElementColor" Value="2161156351"/>
-          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2410282495"/>
-          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/>
-          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4287987967"/>
-          <FCUInt Name="ConstrainedIcoColor" Value="4286170879"/>
-          <FCUInt Name="NonDrivingConstrDimColor" Value="1358593023"/>
-          <FCUInt Name="ConstrainedDimColor" Value="4286170879"/>
-          <FCUInt Name="ExprBasedConstrDimColor" Value="3180591615"/>
-          <FCUInt Name="DeactivatedConstrDimColor" Value="1651680511"/>
-          <FCUInt Name="CursorTextColor" Value="1358593023"/>
-          <FCUInt Name="CursorCrosshairColor" Value="4177064703"/>
-          <FCUInt Name="CreateLineColor" Value="3435973887"/>
+          <FCUInt Name="AnnotationTextColor" Value="3402287871"/> 
+          <FCUInt Name="SketchEdgeColor" Value="4177064703"/> <!-- F8F8F2; Colors outside Sketcher: Edge -->
+          <FCUInt Name="SketchVertexColor" Value="4177064703"/> <!-- F8F8F2; Colors outside Sketcher: Vertex -->
+          <FCUInt Name="EditedEdgeColor" Value="4177064703"/> <!-- F8F8F2; Edge: Unconstrained -->
+          <FCUInt Name="EditedVertexColor" Value="4283782655"/> <!-- FF5555; Vertex: Unconstrained -->
+          <FCUInt Name="ConstructionColor" Value="1465384959"/> <!-- 5757FF; Construction Geometry: Unconstrained -->
+          <!-- 5757FF: This blue is the Triadic complement to Dracula Red -->
+          <FCUInt Name="ExternalColor" Value="4286170879"/> <!-- #ff79c6 (default is cc3373); Extermal geometry -->
+          <FCUInt Name="FullyConstrainedColor" Value="1358593023"/> <!-- 50FA7B; Fully constrained Sketch -->
+          <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/> <!-- B2B27F; Internal alignment edge: Unconstrained -->
+          <FCUInt Name="FullyConstraintElementColor" Value="2161156351"/> <!-- 80d0a0; Edge: Constrained -->
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2678063103"/> <!-- 9F9FFF; Construction geometry: Constrained -->
+          <!-- Lighter tint of 5757FF from above. -->
+          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/> <!-- DEDEC8; Internal alignment edge: Constrained -->
+          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4288651263"/> <!-- FF9F9F; Vertex: Constrained -->
+          <!-- Lighter tint of Dracula Red -->
+          <FCUInt Name="ConstrainedIcoColor" Value="4283782655"/> <!-- FF5555; Constraint symbols -->
+          <FCUInt Name="NonDrivingConstrDimColor" Value="1465384959"/> <!-- 5757FF; Reference constraint -->
+          <FCUInt Name="ConstrainedDimColor" Value="4283782655"/> <!-- FF5555; Dimensional constraint -->
+          <FCUInt Name="ExprBasedConstrDimColor" Value="4290276607"/> <!-- #FFB86C; Expression dependent constraint -->
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2139062271"/> <!-- 7f7f7f; Deactivated constraint -->
+          <FCUInt Name="InvalidSketchColor" Value="4290276607"/> <!-- #FFB86C; Invalid Sketch Color -->
+          <FCUInt Name="CursorTextColor" Value="4177064703"/> <!-- F8F8F2; Coordinate text -->
+          <FCUInt Name="CursorCrosshairColor" Value="4294967295"/> <!-- FFFFFF; Cursor crosshair -->
+          <FCUInt Name="CreateLineColor" Value="4294967295"/> <!-- FFFFFF; Creating line -->
           <FCUInt Name="ShadowLightColor" Value="4043177728"/>
           <FCUInt Name="ShadowGroundColor" Value="2105376000"/>
           <FCUInt Name="HiddenLineColor" Value="0"/>


### PR DESCRIPTION
After working through a few different options in an attempt to fix #30 and fix #31 I landed on this. The process was mostly just looking at the default Sketcher colors and applying the closest Dracula color. The one major color that didn't exist was some form of deeper blue. For that, I used the triadic complement of Dracula Red.

The next largest difference is that the default FC theme's "Magenta" used for external geometry is a bit dark on top of the Dracula background (and always seemed too close to red constraints anyway), so that was switched to Dracula pink. This leaves it in the same family as the default, but matches the theme and is light enough to stand out on the dark background.

To make room for pink and fix #31, HighlightColor was switched to Dracula yellow (darkened 50% due to the 3D view issues outlined in #20). This landed it pretty close to the default FC HighlightColor while keeping a more muted tone.

Before:
[Screencast from 04-27-2023 09:30:16 PM.webm](https://user-images.githubusercontent.com/650565/235045728-dd0fe4ef-94dd-4cb4-81a4-c6b3df58e977.webm)

After:
[Screencast from 04-27-2023 09:27:49 PM.webm](https://user-images.githubusercontent.com/650565/235045741-c38c15f0-9704-4503-a78f-0670038a70f9.webm)

While this sacrifices a little bit of the character/uniqueness, it's still aesthetically pleasing and matches almost all Dracula colors. I think the tradeoff is definitely worth it to make the theme more functional. I felt less dissonance immediately even though I've been working with Dracula for months.