### PR TITLE
Increase contrast of text in disabled text boxes

### DIFF
--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -1266,7 +1266,7 @@ QTextEdit:disabled,
 QTimeEdit:disabled,
 QDateEdit:disabled,
 QDateTimeEdit:disabled {
-    color: #282a36;
+    color: #6272a4;
     background-color: #1b1c24; /* same as enabled color */
     border-color: #1b1c24; /* same as enabled color */
 }


### PR DESCRIPTION
Before:
![before lightendisabledtext](https://github.com/dracula/freecad/assets/650565/63b95de5-8869-4bba-a9ec-a8c092e95481)

After (matches disabled color in QMenuBar):
![after lightendisabledtext](https://github.com/dracula/freecad/assets/650565/af9294b1-1186-4296-a366-1f6244dc24f1)

One-line change but it applies to a lot of widgets; did my best to browse around and look for problems but would like someone else to test as well in case I missed anything.