### PR TITLE
Update Property Editor colors for better contrast and consistency

### DIFF
--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -852,6 +852,10 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
 	background-color: #6272a4; /* same as focused background color */
 }
 
+QLabel[haslink="true"] { /* applies to all links, but most importantly in PropertyEditor. Trying to specify PropertyEditor fails.*/
+    color: #8be9fd;
+}
+
 /* hack to disable margin inside Property values to following elements */
 Gui--PropertyEditor--PropertyEditor QSpinBox,
 Gui--PropertyEditor--PropertyEditor QDoubleSpinBox,

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -846,18 +846,6 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel:disabled {
     padding: 0px;
 }
 
-/* hack to hide non editable cells inside Property values */
-Gui--PropertyEditor--PropertyEditor QLineEdit:read-only,
-Gui--PropertyEditor--PropertyEditor QLineEdit:disabled,
-Gui--PropertyEditor--PropertyEditor QAbstractSpinBox:read-only,
-Gui--PropertyEditor--PropertyEditor QAbstractSpinBox:disabled {
-    color: transparent;
-    border-color: transparent;
-    background-color: transparent;
-    selection-color: transparent;
-    selection-background-color: transparent;
-}
-
 /* hack to hide weird redundant information inside cells with links and no editable data (but editable via "..." button) */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
 	color: #bd93f9;
@@ -929,19 +917,6 @@ QTreeView > QWidget > QDateEdit:focus,
 QTreeView > QWidget > QDateTimeEdit:focus {
     border-color: #1b1c24; /* same as focused background color */
     border-bottom-color: black; /* same as focused border color */
-}
-
-QTreeView > QWidget > QAbstractSpinBox:read-only,
-QTreeView > QWidget > QSpinBox:read-only,
-QTreeView > QWidget > QDoubleSpinBox:read-only,
-QTreeView > QWidget > QLineEdit:read-only,
-QTreeView > QWidget > QTextEdit:read-only,
-QTreeView > QWidget > QTimeEdit:read-only,
-QTreeView > QWidget > QDateEdit:read-only,
-QTreeView > QWidget > QDateTimeEdit:read-only {
-    color: transparent;
-    background-color: transparent;
-    border-color: transparent;
 }
 
 /* Fix to correctly (not totally) draw QTextEdit on OSX at Page properties: "Page result", "Template" and "Editable Texts" */

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -830,29 +830,22 @@ Gui--PropertyEditor--PropertyEditor {
     gridline-color: #1b1c24; /* same as Group header background */
 }
 
-/* fix for column items background when a link is present */
-Gui--PropertyEditor--PropertyEditor > QWidget > QFrame:focus {
-    background-color: #6272a4; /* same as focused background color */
-}
-
-/* hack to hide weird redundant information inside the value of a Placement cell */
-Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel,
-Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel:disabled {
-    color: transparent;
-    background-color: transparent;
-    border: none;
-    border-radius: 0px;
-    margin: 0px;
-    padding: 0px;
-}
-
-/* hack to hide weird redundant information inside cells with links and no editable data (but editable via "..." button) */
+/* Cells with values that can only be changed with "..." button (Attachment)
+/* These seem to draw on top of the underlying label, so can't be transparent */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
-	color: #bd93f9;
-	background-color: #6272a4; /* same as focused background color */
+	color: #ffb86c;
+	background-color: #6272a4;
+	margin-left:1px;
 }
 
-QLabel[haslink="true"] { /* applies to all links, but most importantly in PropertyEditor. Trying to specify PropertyEditor fails.*/
+/* Cells with values that can only be changed with "..." button, but are disabled (Placement) */
+/* These seem to draw on top of the underlying label, so can't be transparent */
+Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel:disabled {
+	color: #acadb6;
+	background-color: #6272a4;
+}
+
+QLabel[haslink="true"] { /* applies to all links (See Help->About), but most importantly in PropertyEditor. Trying to specify PropertyEditor fails.*/
     color: #8be9fd;
 }
 
@@ -919,7 +912,7 @@ QTreeView > QWidget > QTextEdit:focus,
 QTreeView > QWidget > QTimeEdit:focus,
 QTreeView > QWidget > QDateEdit:focus,
 QTreeView > QWidget > QDateTimeEdit:focus {
-    border-color: #1b1c24; /* same as focused background color */
+    border-color: transparent; /* same as focused background color */
     border-bottom-color: black; /* same as focused border color */
 }
 
@@ -1283,7 +1276,7 @@ QTextEdit:disabled,
 QTimeEdit:disabled,
 QDateEdit:disabled,
 QDateTimeEdit:disabled {
-    color: #282a36;
+    color: #6272a4;
     background-color: #1b1c24; /* same as enabled color */
     border-color: #1b1c24; /* same as enabled color */
 }

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -831,7 +831,7 @@ Gui--PropertyEditor--PropertyEditor {
 }
 
 /* Cells with values that can only be changed with "..." button (Attachment)
-/* These seem to draw on top of the underlying label, so can't be transparent */
+/* These seem to draw on top of the underlying label, so must be completely hidden or have an opaque background */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
 	color: #ffb86c;
 	background-color: #6272a4;
@@ -839,10 +839,10 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
 }
 
 /* Cells with values that can only be changed with "..." button, but are disabled (Placement) */
-/* These seem to draw on top of the underlying label, so can't be transparent */
+/* These seem to draw on top of the underlying label, so must be completely hidden or have an opaque background */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel:disabled {
-	color: #acadb6;
-	background-color: #6272a4;
+	color: transparent;
+	background-color: transparent;
 }
 
 QLabel[haslink="true"] { /* applies to all links (See Help->About), but most importantly in PropertyEditor. Trying to specify PropertyEditor fails.*/
@@ -859,6 +859,14 @@ Gui--PropertyEditor--PropertyEditor QComboBox {
     margin-right: 0px;
     padding-top: 0px;
     padding-bottom: 0px;
+}
+
+Gui--PropertyEditor--PropertyEditor QSpinBox:disabled,
+Gui--PropertyEditor--PropertyEditor QDoubleSpinBox:disabled,
+Gui--PropertyEditor--PropertyEditor QAbstractSpinBox:disabled,
+Gui--PropertyEditor--PropertyEditor QLineEdit:disabled,
+Gui--PropertyEditor--PropertyEditor QComboBox:disabled {
+    selection-background-color:transparent;
 }
 
 /* reset min-height to 0px inside list views */

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -1034,7 +1034,7 @@ QSplitter::handle {
 }
 
 QSplitter::handle:horizontal {
-    background-image: url(qss:images_dark-light/splitter_vertical_dark.svg);
+    background-image: url(qss:images_dark-light/splitter_vertical_light.svg);
     background-position: center center;
     background-repeat: none;
     margin: 4px 2px 4px 2px;
@@ -1042,7 +1042,7 @@ QSplitter::handle:horizontal {
 }
 
 QSplitter::handle:vertical {
-    background-image: url(qss:images_dark-light/splitter_horizontal_dark.svg);
+    background-image: url(qss:images_dark-light/splitter_horizontal_light.svg);
     background-position: center center;
     background-repeat: none;
     margin: 2px 4px 2px 4px;
@@ -1057,13 +1057,13 @@ QMainWindow::separator {
 
 QMainWindow::separator:horizontal {
     height: 2px;
-    background-image: url(qss:images_dark-light/splitter_horizontal_dark.svg);
+    background-image: url(qss:images_dark-light/splitter_horizontal_light.svg);
     margin: 4px 2px 4px 2px;
 }
 
 QMainWindow::separator:vertical {
     width: 2px;
-    background-image: url(qss:images_dark-light/splitter_vertical_dark.svg);
+    background-image: url(qss:images_dark-light/splitter_vertical_light.svg);
     margin: 2px 4px 2px 4px;
 }
 


### PR DESCRIPTION
An update for Property Editor. Implements the [[hasLink] feature](https://forum.freecad.org/viewtopic.php?t=50744) to increase contrast of links. Switches purple text of "..." editable fields to Dracula orange for more contrast. Adjusts borders and margins of focused controls to make edges consistent. Switches splitters (drag handles) to light color. Removes some seemingly unnecessary code after testing.

Fixes #44
Fixes #39 

Before:
https://github.com/dracula/freecad/assets/650565/f2b635e7-5cf1-4e6c-82b6-28f5f6e87ba6

After:
https://github.com/dracula/freecad/assets/650565/a3288b88-45ca-408b-a66d-f79239872c0a

(These MP4 files won't play in Firefox for me, may need to be opened in VLC.)