### PR TITLE
Lighten icons

### DIFF
--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -765,29 +765,29 @@ QTabBar QToolButton::left-arrow { /* the arrow mark in the tool buttons */
 }
 
  QTabBar QToolButton::up-arrow:enabled {
-     image: url(qss:images_dark-light/up_arrow_dark.svg);
+     image: url(qss:images_dark-light/up_arrow_light.svg);
 }
 
  QTabBar QToolButton::up-arrow:disabled,
  QTabBar QToolButton::up-arrow:off {
-     image: url(qss:images_dark-light/up_arrow_disabled_dark.svg);
+     image: url(qss:images_dark-light/up_arrow_disabled_light.svg);
 }
 
  QTabBar QToolButton::up-arrow:hover {
-     image: url(qss:images_dark-light/up_arrow_darker.svg);
+     image: url(qss:images_dark-light/up_arrow_lighter.svg);
 }
 
  QTabBar QToolButton::down-arrow:enabled {
-     image: url(qss:images_dark-light/down_arrow_dark.svg);
+     image: url(qss:images_dark-light/down_arrow_light.svg);
 }
 
  QTabBar QToolButton::down-arrow:disabled,
  QTabBar QToolButton::down-arrow:off {
-     image: url(qss:images_dark-light/down_arrow_disabled_dark.svg);
+     image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
 }
 
  QTabBar QToolButton::down-arrow:hover {
-     image: url(qss:images_dark-light/down_arrow_darker.svg);
+     image: url(qss:images_dark-light/down_arrow_lighter.svg);
 }
 
 QTabBar::tear {
@@ -1404,7 +1404,7 @@ QDoubleSpinBox::up-arrow:off,
 QTimeEdit::up-arrow:off,
 QDateEdit::up-arrow:off,
 QDateTimeEdit::up-arrow:off {
-    image: url(qss:images_dark-light/up_arrow_disabled_dark.svg);
+    image: url(qss:images_dark-light/up_arrow_disabled_light.svg);
 }
 
 QAbstractSpinBox::up-arrow:disabled,
@@ -1413,7 +1413,7 @@ QDoubleSpinBox::up-arrow:disabled,
 QTimeEdit::up-arrow:disabled,
 QDateEdit::up-arrow:disabled,
 QDateTimeEdit::up-arrow:disabled {
-    image: url(qss:images_dark-light/up_arrow_disabled_dark.svg);
+    image: url(qss:images_dark-light/up_arrow_disabled_light.svg);
 }
 
 QAbstractSpinBox::down-arrow,
@@ -1441,7 +1441,7 @@ QDoubleSpinBox::down-arrow:off,
 QTimeEdit::down-arrow:off,
 QDateEdit::down-arrow:off,
 QDateTimeEdit::down-arrow:off {
-    image: url(qss:images_dark-light/down_arrow_disabled_dark.svg);
+    image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
 }
 
 QAbstractSpinBox::down-arrow:disabled,
@@ -1450,7 +1450,7 @@ QDoubleSpinBox::down-arrow:disabled,
 QTimeEdit::down-arrow:disabled,
 QDateEdit::down-arrow:disabled,
 QDateTimeEdit::down-arrow:disabled {
-    image: url(qss:images_dark-light/down_arrow_disabled_dark.svg);
+    image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
 }
 
 /* ComboBox */
@@ -1480,7 +1480,7 @@ QComboBox::down-arrow:focus {
 
 QComboBox::down-arrow:off,
 QComboBox::down-arrow:disabled {
-    image: url(qss:images_dark-light/down_arrow_disabled_dark.svg);
+    image: url(qss:images_dark-light/down_arrow_disabled_light.svg);
 }
 
 /* ComboBox menu */

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -2067,24 +2067,23 @@ QToolBar > QToolButton:checked:hover {
 
 /*The "show more" button  (it can also be stylable with "QToolBarExtension" */
 QToolBar QToolButton#qt_toolbar_ext_button {
-    margin: 0px;
+    margin: 1px;
     padding: 0px;
-    /*background-image: url(qss:images_dark-light/more_dark.svg);*/
+    qproperty-icon: url(qss:images_dark-light/more_light.svg);
     image: transparent;
     background-repeat: none;
     background-position: center left;
 }
 
 QToolBar QToolButton#qt_toolbar_ext_button:hover {
-    /*background-image: url(qss:images_dark-light/more_light.svg);*/
+    qproperty-icon: url(qss:images_dark-light/more_light.svg);
     border-color: #1b1c24;
-    background-color: #1b1c24;
-}
+    background-color: rgba(255,255,255,20)}
 
 QToolBar QToolButton#qt_toolbar_ext_button:on {
-    /*background-image: url(qss:images_dark-light/more_light.svg);*/
+    qproperty-icon: url(qss:images_dark-light/more_light.svg);
     border-color: #1b1c24;
-    background-color: #1b1c24;
+    background-color: #6272a4;
 }
 
 

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -1684,7 +1684,7 @@ Radio button
 QRadioButton::indicator:unchecked{
     color: black;
     background-color: rgba(0,0,0,40);
-    border: 1px solid #282a36;
+    border: 1px solid #6272a4;
 }
 
 QRadioButton::indicator:checked {
@@ -1723,7 +1723,7 @@ QRadioButton::indicator:disabled {
 }
 
 QRadioButton:focus {
-    border: none;
+    border: 1px solid #535d7f;
 }
 
 
@@ -1742,7 +1742,7 @@ QCheckBox::indicator,
 QGroupBox::indicator {
     color: black;
     background-color: rgba(0,0,0,40);
-    border: 1px solid #282a36;
+    border: 1px solid #6272a4;
     width: 11px;
     height: 11px;
     border-radius:2px;
@@ -1785,7 +1785,7 @@ QGroupBox::indicator:indeterminate {
 }
 
 QCheckBox:focus {
-    border: none;
+    border: 1px solid #535d7f;
 }
 
 


### PR DESCRIPTION
Commit messages pretty much cover it

Checkboxes & radio buttons, before:
![Checkbox before](https://github.com/dracula/freecad/assets/650565/83ddb567-a3f9-45b3-88db-02dd7ee07424)

Checkboxes & radio buttons, after:
![Checkbox after](https://github.com/dracula/freecad/assets/650565/85f21b80-3283-4b17-bc79-6b4e0156ac4d)

Deactivated spinbox arrows, before:
![Icons Before](https://github.com/dracula/freecad/assets/650565/7fc488e7-644d-4d9b-8845-04af03e6a420)

Deactived spinbox arrows, after:
![Icons after](https://github.com/dracula/freecad/assets/650565/5445aecc-1030-45e9-8afc-8e0355abc5e0)

Toolbar-ext buttons before:
![Low Contrast toolbar-ext buttons](https://github.com/dracula/freecad/assets/650565/64edfcfd-b76f-412b-be27-300185038430)

Toolbar-ext buttons after:
![Toolbar-ext after](https://github.com/dracula/freecad/assets/650565/ee210849-4599-4912-b000-bc273bf0dcae)

Fixes #38
Fixes #46 