### PR TITLE
Prefpackbutton overlapfix

### DIFF
--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -1590,7 +1590,7 @@ QPushButton:checked {
     border-color: #6272a4;
 }
 
-/* For styling Buttons inside tables, found in Preferences > Workbenches */
+/* For styling Buttons inside tables, found in Preferences > Preference Packs */
 /* Padding & margins specifically for these buttons prevents overlap of buttons between table rows */
 QTableWidget QPushButton {
     padding-top:1px;

--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -1590,6 +1590,19 @@ QPushButton:checked {
     border-color: #6272a4;
 }
 
+/* For styling Buttons inside tables, found in Preferences > Workbenches */
+/* Padding & margins specifically for these buttons prevents overlap of buttons between table rows */
+QTableWidget QPushButton {
+    padding-top:1px;
+    padding-bottom:1px;
+    padding-left:6px;
+    padding-right:6px;
+    margin-top:1.5px;
+    margin-bottom:1.5px;
+    margin-left:2px;
+    margin-right:2px;
+}
+
 
 /*==================================================================================================
 Tool button inside QDialogs that works as QPushButtons


### PR DESCRIPTION
Before:
![Overlap before](https://github.com/dracula/freecad/assets/650565/28d7362d-5ec8-437e-865d-8f3a5321b065)

After:
![Overlap after](https://github.com/dracula/freecad/assets/650565/54f1ea9b-31f1-458b-a8b5-a26140401f58)

Fixes #36 