### PR TITLE
Combo box color fixes

### DIFF
--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -1471,12 +1471,12 @@ QComboBox {
 
 QComboBox QAbstractItemView {
     color: #9799a3; /* same as regular QComboBox color */
-    background-color: transparent;
+    background-color:  #1b1c24;
     selection-color: #eaebed;
     selection-background-color: #6272a4;
     border-width: 5px 0px 5px 0px;
     border-style: solid;
-    border-color: transparent;
+    border-color: #1b1c24;
     margin: 0px -1px 0px 0px; /* hack for Mac... try it on Windows and Linux */
 }
 

--- a/Dracula/overlay/Dracula-overlay.qss
+++ b/Dracula/overlay/Dracula-overlay.qss
@@ -20,14 +20,6 @@ QTabWidget::pane {
   border: transparent;
 }
 
-QAbstractItemView {
-  background-color: transparent;
-  alternate-background-color: #1b1c24; /* related with QListView background  */
-  color: #65A2E5;
-  border: transparent;
-  padding-right: 5px;
-}
-
 Gui--OverlayTitleBar,
 Gui--OverlaySplitterHandle {
   background-color: transparent;

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>Dracula</name>
   <description>Dracula dark theme for FreeCAD</description>
-  <version>0.0.7</version>
+  <version>0.0.8</version>
   <maintainer email="eleanor@clifford.lol">Eleanor Clifford</maintainer>
   <license file="LICENSE">MIT</license>
   <url type="repository" branch="master">https://github.com/dracula/freecad</url>


### PR DESCRIPTION
Offending ComboBoxes before:
<img width="620" height="340" alt="ComboBox Before" src="https://github.com/user-attachments/assets/5cc488f6-85d4-4d85-ae19-3539ecb74a90" />
<img width="367" height="299" alt="OverLay Before" src="https://github.com/user-attachments/assets/d8d19260-65ac-464c-a490-12d8cf761590" />

Same ComboBoxes after:
<img width="616" height="502" alt="ComboBox After" src="https://github.com/user-attachments/assets/f16715f3-aabf-4d40-bf35-300912577e58" />
<img width="368" height="236" alt="OverLay ComboBox After" src="https://github.com/user-attachments/assets/d2c04b8f-42c7-4cdb-9ff5-3313e247cba1" />

Still need to figure out the white border (stacked elements?) but this it's unusable as is so pushing right away.