### PR TITLE
Notification popup fix

### DIFF
--- a/Dracula/Dracula.qss
+++ b/Dracula/Dracula.qss
@@ -81,6 +81,10 @@ Reset elements
     color: #eaebed; /* Default color for labels and different text elements that usually use dark colors */
 }
 
+QLabel {
+    background-color: transparent /* Required to show the contents of Gui--NotificationLabel */
+}
+
 /* specific reset for elements inside QToolBar */
 QToolBar * {
     margin: 0px;
@@ -1087,6 +1091,17 @@ QPlainTextEdit:focus {
     border: 1px solid #1b1c24;
     border-radius: 3px;
     margin: 4px;
+}
+
+
+/*==================================================================================================
+Notification / error popup box
+==================================================================================================*/
+
+Gui--NotificationLabel {
+  background-color: #282a36;
+  border: 1px solid #020202;
+  border-radius: 2px;
 }
 
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>Dracula</name>
   <description>Dracula dark theme for FreeCAD</description>
-  <version>0.0.8</version>
+  <version>0.0.9</version>
   <maintainer email="eleanor@clifford.lol">Eleanor Clifford</maintainer>
   <license file="LICENSE">MIT</license>
   <url type="repository" branch="master">https://github.com/dracula/freecad</url>


### PR DESCRIPTION
Before:
<img width="1211" height="268" alt="image" src="https://github.com/user-attachments/assets/56958537-0ec1-4886-b6ad-9e2b5b1a390f" />

After:
<img width="1203" height="255" alt="image" src="https://github.com/user-attachments/assets/19ca38d6-9a5a-424f-ba1e-27e56b00d878" />

The QLabel change is across the entire app, so I'm not pushing until someone else can test as well. I don't think a QLabel could exist anywhere there *isn't* already a background, but I've been surprised before. Like by having to set the transparency for this PR even. 🤦